### PR TITLE
Remove PyPDF2 as it is vulnerable

### DIFF
--- a/LLM/rag/requirements.txt
+++ b/LLM/rag/requirements.txt
@@ -5,7 +5,6 @@ langchain-huggingface==0.1.2
 huggingface-hub==0.29.1
 sentence-transformers==3.4.1
 chromadb==0.6.3
-PyPDF2==3.0.1
 transformers==4.48.3
 pypdf==5.3.0
 torch==2.6.0


### PR DESCRIPTION
PyPDF2 is vulnerable and is not used in code.